### PR TITLE
docs: Drop broken lightning intersphinx mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,6 @@ autodoc_member_order = "bysource"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
-    "lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
 }
 
 html_favicon = "icons/favicon.ico"

--- a/docs/source/examples/lightning_integration.rst
+++ b/docs/source/examples/lightning_integration.rst
@@ -1,13 +1,13 @@
 PyTorch Lightning Integration
 =============================
 
-To use Jacobian descent with TorchJD in a :class:`~lightning.pytorch.core.LightningModule`, you need
+To use Jacobian descent with TorchJD in a ``LightningModule``, you need
 to turn off automatic optimization by setting ``automatic_optimization`` to ``False`` and to
 customize the ``training_step`` method to make it call the appropriate TorchJD method
 (:doc:`backward <../docs/autojac/backward>` or :doc:`mtl_backward <../docs/autojac/mtl_backward>`).
 
 The following code example demonstrates a basic multi-task learning setup using a
-:class:`~lightning.pytorch.core.LightningModule` that will call :doc:`mtl_backward
+``LightningModule`` that will call :doc:`mtl_backward
 <../docs/autojac/mtl_backward>` at each training iteration.
 
 .. testsetup::


### PR DESCRIPTION
Lightning's docs site no longer serves a Sphinx `objects.inv`, breaking the docs build. Removes the dead intersphinx mapping and inlines the `LightningModule` references as plain code.

This should fix the CI.